### PR TITLE
Fix handling systems without RAID controllers

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -735,7 +735,7 @@ def configure_raid(ironic_client, node_uuid, role, os_volume_size_gb,
     when RAID configuration failed and return False. Further testing
     should uncover interesting error conditions.'''
 
-    if get_raid_controller_ids(drac_client) is None:
+    if not get_raid_controller_ids(drac_client):
         LOG.warning("No RAID controller is present.  Skipping RAID "
                     "configuration")
         return True


### PR DESCRIPTION
Systems without RAID controllers were not detected correctly and proceeded trying to configure RAID.
It proceeded until it correctly determined that there are no RAID controllers but emitted a number of confusing log messages before that.

With this change the check at the very beginning of RAID configuration for no RAID controllers is fixed by also checking for empty lists, so it exits at the beginning of RAID configuration without producing confusing log messages.